### PR TITLE
Fixed with lime 2.0.0-alpha.4

### DIFF
--- a/Source/Main.hx
+++ b/Source/Main.hx
@@ -5,15 +5,20 @@ import openfl.Lib;
 import openfl.events.MouseEvent;
 
 class Main extends Sprite
-{	
+{    
 	public var drag:Bool;
 	public var offsetX:Int;
 	public var offsetY:Int;
+	public var winX:Int;
+	public var winY:Int;
 
 	public function new() 
 	{
 		super();
-		
+
+		winX = 0;
+		winY = 0;
+
 		Lib.current.stage.addEventListener(MouseEvent.MOUSE_DOWN, mouseDown);
 		Lib.current.stage.addEventListener(MouseEvent.MOUSE_UP, mouseUp);
 		Lib.current.stage.addEventListener(MouseEvent.MOUSE_MOVE, mouseMove);
@@ -21,24 +26,24 @@ class Main extends Sprite
 
 	function mouseDown(event:MouseEvent)
 	{
-   		offsetX = Std.int(event.localX);
-   		offsetY = Std.int(event.localY);
-   		drag = true;
+		offsetX = Std.int(event.localX);
+		offsetY = Std.int(event.localY);
+		drag = true;
 	}
 
 	function mouseUp(event:MouseEvent)
 	{
-	   	drag = false;
+		drag = false;
 	}
 
 	function mouseMove(event:MouseEvent)
 	{
-	   	if (drag)
-	   	{
-	   		var winX = Lib.application.window.x;
-	   		var winY = Lib.application.window.y;	   		
+		if (drag)
+		{
+			winX = winX + Std.int(event.localX) - offsetX;
+			winY = winY + Std.int(event.localY) - offsetY;
 
-	   		Lib.application.window.move(winX + Std.int(event.localX) - offsetX, winY + Std.int(event.localY) - offsetY);
-	   	}	
+			Lib.application.window.move(winX, winY);
+		}
 	}
 }


### PR DESCRIPTION
Fix for new version of Lime.

We have to store window's position in variables and operate on them before setting it to window's x and y.

Thanks for the help again :smiley: 
